### PR TITLE
Fix the three following code errors

### DIFF
--- a/Chapters/DoubleDispatch/DoubleDispatch.pillar
+++ b/Chapters/DoubleDispatch/DoubleDispatch.pillar
@@ -19,8 +19,8 @@ The following tests show these two behaviors: First the dice handle creation and
 DieHandleTest >> testCreationAdding
 	| handle |
 	handle := DieHandle new
-		addDice: (Dice faces: 6);
-		addDice: (Dice faces: 10);
+		addDie: (Die faces: 6);
+		addDie: (Die faces: 10);
 		yourself.
 	self assert: handle diceNumber = 2
 ]]]
@@ -273,7 +273,7 @@ Die >> sumWithHandle: aDieHandle
 	| handle |
 	handle := DieHandle new.
 	aDieHandle dice do: [ :each | handle addDie: each ].
-	handle addDie: self
+	handle addDie: self.
 	^ handle
 ]]]
 

--- a/Chapters/Expression/Expression.pillar
+++ b/Chapters/Expression/Expression.pillar
@@ -945,7 +945,7 @@ EVariable >> id: aSymbol
 
 [[[
 EVariable >> printOn: aStream
-	aStream nexPutAll: id asString
+	aStream nextPutAll: id asString
 ]]]
 What we see is that we need to be able to pass bindings (a binding is a pair key, value) when evaluating a variable. The value of a variable is the value of the binding whose key is the name of the variable. 
 


### PR DESCRIPTION
- page 43: nextPutAll message mispelled
- page 50: add Die : Die instead of addDice : Dice
- page 57: a dot was missing

Changes to be committed:
	modified:   Chapters/DoubleDispatch/DoubleDispatch.pillar
	modified:   Chapters/Expression/Expression.pillar: